### PR TITLE
Add SQL-based model and session helper

### DIFF
--- a/database/__init__.py
+++ b/database/__init__.py
@@ -1,6 +1,26 @@
 """Database related modules."""
-"""Database related modules"""
+from __future__ import annotations
 
-from .db import init_db, add_user
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
 
-__all__ = ["init_db", "add_user"]
+DB_PATH = Path("database/bot.db")
+
+
+@contextmanager
+def get_session() -> Iterator[sqlite3.Connection]:
+    """Yield a SQLite connection for database operations."""
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+from .db import init_db, add_user  # noqa: E402
+
+__all__ = ["init_db", "add_user", "get_session", "DB_PATH"]
+

--- a/database/db.py
+++ b/database/db.py
@@ -2,26 +2,35 @@
 from __future__ import annotations
 
 import sqlite3
-from pathlib import Path
 
-DB_PATH = Path("database/bot.db")
+from . import get_session
+
 
 
 def init_db() -> None:
     """Initialize the database and create required tables."""
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with sqlite3.connect(DB_PATH) as conn:
+    with get_session() as conn:
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS users (id INTEGER PRIMARY KEY, username TEXT, join_date TEXT)"
+            """
+            CREATE TABLE IF NOT EXISTS users (
+                id INTEGER PRIMARY KEY,
+                username TEXT,
+                full_name TEXT,
+                join_date TEXT
+            )
+            """
         )
         conn.commit()
 
 
-def add_user(user_id: int, username: str | None, join_date: str) -> None:
+def add_user(user_id: int, username: str | None, full_name: str | None, join_date: str) -> None:
     """Insert or update a user in the database."""
-    with sqlite3.connect(DB_PATH) as conn:
+    with get_session() as conn:
         conn.execute(
-            "INSERT OR REPLACE INTO users (id, username, join_date) VALUES (?, ?, ?)",
-            (user_id, username, join_date),
+            """
+            INSERT OR REPLACE INTO users (id, username, full_name, join_date)
+            VALUES (?, ?, ?, ?)
+            """,
+            (user_id, username, full_name, join_date),
         )
         conn.commit()

--- a/database/models.py
+++ b/database/models.py
@@ -1,0 +1,16 @@
+"""Data models for the database."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+
+@dataclass(slots=True)
+class User:
+    """Representation of a bot user."""
+
+    id: int
+    username: str | None
+    full_name: str | None
+    join_date: datetime
+

--- a/handlers/user/start.py
+++ b/handlers/user/start.py
@@ -27,6 +27,7 @@ async def cmd_start(message: Message) -> None:
         add_user,
         message.from_user.id,
         message.from_user.username,
+        message.from_user.full_name,
         join_date,
     )
 


### PR DESCRIPTION
## Summary
- replace SQLAlchemy setup with a lightweight sqlite3 session helper
- define `User` dataclass model
- update DB helper functions and start handler to work with new schema
- clean up requirements

## Testing
- `pip install -q -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b714831c8832987772bdd2faef49b